### PR TITLE
Separate out optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,24 @@ readme = "README.md"
 license = {file = "LICENSE.md"}
 requires-python = ">=3.9.10"
 
-dependencies = ["torch>=1.13","torchvision>=0.13", "palmerpenguins>=0.1.4",
-                "pandas", "mypy", "pydocstyle", "black", "ipykernel"]
+dependencies = [
+    "torch>=1.13",
+    "torchvision>=0.13",
+    "palmerpenguins>=0.1.4",
+    "pandas",
+    "ipykernel",
+]
 
+[project.optional-dependencies]
+# test = [
+#     "pytest>=7.2.0",
+# ]
+lint = [
+    "black>=22.12.0",
+    # "pylint",
+    "pydocstyle",
+    "mypy>=1.0.0",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/Cambridge-ICCS/ml-training-material"


### PR DESCRIPTION
Edited pyproject.toml to create a `lint` install.
This means summer school users will only need to install dependencies that are required to **use** the code.

The full set of dependencies (including linting) can be installed using:
```
pip install '.[lint]' 
```

I have left a placeholders for tests and pylint as comments should we want it in future.