### PR TITLE
Add mnist-data to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Downloaded data
+mnist-data/


### PR DESCRIPTION
Added the `mnist-data/` folder to the .gitignore

It'd be useful to have this in the gitignore for people running the scripts locally.